### PR TITLE
Correct URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [hopeinsource.com](hopeinsource.com)
+# [hopeinsource.com](https://hopeinsource.com)
 
 ## Run
 


### PR DESCRIPTION
Corrected the title URL in the README because without the `https://` GitHub would consider it as a regular file in the root of the repository.